### PR TITLE
Allow cancelling of requests from the a client

### DIFF
--- a/src/jhi/brapi/client/RetrofitServiceGenerator.java
+++ b/src/jhi/brapi/client/RetrofitServiceGenerator.java
@@ -134,4 +134,9 @@ public class RetrofitServiceGenerator
 	{
 		return retrofit;
 	}
+
+	public void cancelAll()
+	{
+		httpClient.dispatcher().cancelAll();
+	}
 }


### PR DESCRIPTION
Expose the ability to cancel an http request to the client, this can be
useful if the user suspects the request is timing out.